### PR TITLE
make binary work when cutest.rb is not in ../lib

### DIFF
--- a/bin/cutest
+++ b/bin/cutest
@@ -1,4 +1,5 @@
-require File.expand_path("../lib/cutest", File.dirname(__FILE__))
+$:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
+require 'cutest'
 
 if ARGV.empty?
   puts "usage: cutest [-r lib] [-v] file ..."


### PR DESCRIPTION
debian installs libraries to /usr/lib/ruby/vendor_ruby as per debian policy. /usr/bin/cutest was not able to find cutest.rb file with current code. Change suggested by Lucas Nussbaum of debian-ruby team (I'm packaging cutest in debian).
