### PR TITLE
Run all tests in one go (vs. quit on first fail)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,9 +6,9 @@ Forking tests.
 Description
 -----------
 
-Each test file is run in a forked process to avoid shared state. Once a failure
-is found, you get a report detailing what failed and how to locate the error
-and the rest of the file is skipped.
+Each test file is run in a forked process to avoid shared state. After all
+tests are run, you get a report detailing what failed and how to locate the
+errors.
 
 You can use the `scope` command around tests: it guarantees that no instance
 variables are shared between tests.

--- a/test/fixtures/fail_custom_assertion.rb
+++ b/test/fixtures/fail_custom_assertion.rb
@@ -1,6 +1,5 @@
 def assert_empty(string)
   flunk("not empty") unless string.empty?
-  success
 end
 
 test "failed custom assertion" do

--- a/test/run.rb
+++ b/test/run.rb
@@ -1,5 +1,7 @@
 test "output of successful run" do
-  expected = ".\n"
+  expected = <<-EXP.gsub(/^[ ]{4}/, '')
+    test/fixtures/success.rb: [.]
+  EXP
 
   out = %x{./bin/cutest test/fixtures/success.rb}
 
@@ -7,19 +9,27 @@ test "output of successful run" do
 end
 
 test "output of failed run" do
-  expected = "  line: assert false\n" +
-             "  file: test/fixtures/failure.rb +2\n\n" +
-             "Cutest::AssertionFailed: expression returned false\n\n"
+  expected = <<-EXP.gsub(/^[ ]{4}/, '')
+    test/fixtures/failure.rb: [F]
+
+    file: test/fixtures/failure.rb +2
+    line: assert false
+    Cutest::AssertionFailed: expression returned false
+  EXP
 
   out = %x{./bin/cutest test/fixtures/failure.rb}
 
   assert_equal(expected, out)
 end
 
-test "output of failed run" do
-  expected = "  line: raise \"Oops\"\n" +
-             "  file: test/fixtures/exception.rb +2\n\n" +
-             "RuntimeError: Oops\n\n"
+test "output of non-assertion exception" do
+  expected = <<-EXP.gsub(/^[ ]{4}/, '')
+    test/fixtures/exception.rb: [E]
+
+    file: test/fixtures/exception.rb +2
+    line: raise "Oops"
+    RuntimeError: Oops
+  EXP
 
   out = %x{./bin/cutest test/fixtures/exception.rb}
 
@@ -27,9 +37,13 @@ test "output of failed run" do
 end
 
 test "output of custom assertion" do
-  expected = "  line: assert_empty \"foo\"\n" +
-             "  file: test/fixtures/fail_custom_assertion.rb +7\n\n" +
-             "Cutest::AssertionFailed: not empty\n\n"
+  expected = <<-EXP.gsub(/^[ ]{4}/, '')
+    test/fixtures/fail_custom_assertion.rb: [F]
+
+    file: test/fixtures/fail_custom_assertion.rb +6
+    line: assert_empty "foo"
+    Cutest::AssertionFailed: not empty
+  EXP
 
   out = %x{./bin/cutest test/fixtures/fail_custom_assertion.rb}
 
@@ -37,9 +51,13 @@ test "output of custom assertion" do
 end
 
 test "output of failure in nested file" do
-  expected = "  line: assert false\n" +
-             "  file: test/fixtures/failure.rb +2\n\n" +
-             "Cutest::AssertionFailed: expression returned false\n\n"
+  expected = <<-EXP.gsub(/^[ ]{4}/, '')
+    test/fixtures/failure_in_loaded_file.rb: [F]
+
+    file: test/fixtures/failure.rb +2
+    line: assert false
+    Cutest::AssertionFailed: expression returned false
+  EXP
 
   out = %x{./bin/cutest test/fixtures/failure_in_loaded_file.rb}
 


### PR DESCRIPTION
Hi,

I like cutest and how simple it is, but I found myself wanting a couple of things:
1. Results per test file
2. Not to have the suite quit on the first failure

So this is a pull request that accomplishes those things. I'm not sure if it fits in with your roadmap, but I feel like its in line with what I perceive to be the philosophy of cutest, so I thought I'd send it over.
### Description of changes
1. Added a list of exceptions to the `Thread.current[:cutest]` Hash
2. Moved the logic for catching/handling exceptions from `run_file` into `test`
3. In the output, print the file name above the error line text (because i'm going to the file anyway and the line of code is often just an assert call)
4. Added an `E` result for non-`Cutest::AssertionFailed` exceptions that are caught.

(it sounds like a lot, but it actually isn't all that much - and I updated the relevant tests so that everything's passing)

One nice result is that assertion methods no longer have to do IO to report on their status - they just need to `flunk` if some conditions aren't met, so the only changes to user code this pull request might require are in custom assertions - removing any calls to `success`.

Feel free to let me know what you think, I'd love to hear it.
