### PR TITLE
Use expand_path for the file from cutest -r flag

### DIFF
--- a/bin/cutest
+++ b/bin/cutest
@@ -9,7 +9,7 @@ require_relative "../lib/cutest"
 require_relative "../lib/cutest/vendor/clap"
 
 files = Clap.run ARGV,
-  "-r"      => lambda { |file| require file },
+  "-r"      => lambda { |file| require File.expand_path(file) },
   "-o"      => lambda { |name| cutest[:only] = name },
   "-v"      => lambda { puts Cutest::VERSION }
 


### PR DESCRIPTION
Currently, in ruby 1.9.3p327, I am receiving a 'cannot load such file'
error because the current working directory is not in the Ruby load path
by default. Using File.expand_path is a safe way to ensure we can
require a file in the current working directory without using
require_relative.
