### PR TITLE
Return non-zero exit code for failed run

### DIFF
--- a/lib/cutest.rb
+++ b/lib/cutest.rb
@@ -6,15 +6,21 @@ class Cutest
   end
 
   def self.run(files)
+    exit_code = 0
+
     files.each do |file|
       run_file(file)
 
       Process.wait
 
-      break unless $?.success?
+      unless $?.success?
+        exit_code = 1
+        break
+      end
     end
 
     puts
+    exit exit_code
   end
 
   def self.run_file(file)

--- a/test/run.rb
+++ b/test/run.rb
@@ -6,6 +6,11 @@ test "output of successful run" do
   assert_equal(expected, out)
 end
 
+test "exit code of successful run" do
+  %x{./bin/cutest test/fixtures/success.rb}
+  assert_equal 0, $?.to_i
+end
+
 test "output of failed run" do
   expected = "\n" +
              "  test: failed assertion\n" +
@@ -28,6 +33,11 @@ test "output of failed run" do
   out = %x{./bin/cutest test/fixtures/exception.rb}
 
   assert_equal(expected, out)
+end
+
+test "exit code of failed run" do
+  %x{./bin/cutest test/fixtures/failure.rb}
+  assert $?.to_i != 0
 end
 
 test "output of custom assertion" do


### PR DESCRIPTION
I think because .run invokes run_file, and run_file forks,
the exit status from the fork is swallowed.

Implementing non-zero exits from .run allows for CI, etc, to
use the exit status.
