### PR TITLE
Reset block name after test

### DIFF
--- a/lib/cutest.rb
+++ b/lib/cutest.rb
@@ -144,6 +144,8 @@ private
       prepare.each { |blk| blk.call }
       block.call(setup && setup.call)
     end
+
+    cutest[:test] = nil
   end
 
   # Assert that value is not nil or false.

--- a/test/fixtures/outside_block.rb
+++ b/test/fixtures/outside_block.rb
@@ -1,0 +1,5 @@
+test "named success" do
+  assert true
+end
+
+assert false

--- a/test/run.rb
+++ b/test/run.rb
@@ -64,3 +64,15 @@ test "output of failure in nested file" do
 
   assert_equal(expected, out)
 end
+
+test "output of failure outside block" do
+  expected = ".\n" +
+  "  test: \n" +
+  "  line: assert false\n" +
+  "  file: test/fixtures/outside_block.rb +5\n\n" +
+  "Cutest::AssertionFailed: expression returned false\n\n"
+
+  out = %x{./bin/cutest test/fixtures/outside_block.rb}
+
+  assert_equal(expected, out)
+end


### PR DESCRIPTION
Avoid incorrect test name display on next failure.
