### PR TITLE
Add setting to opt-out of forking.

### DIFF
--- a/test/fixtures/check_pid.rb
+++ b/test/fixtures/check_pid.rb
@@ -1,0 +1,3 @@
+test 'this process is the same as the parent' do
+  assert_equal Process.pid, PID
+end

--- a/test/keep_pid.rb
+++ b/test/keep_pid.rb
@@ -1,0 +1,1 @@
+PID = Process.pid

--- a/test/run_without_fork.rb
+++ b/test/run_without_fork.rb
@@ -1,0 +1,15 @@
+test "test can be run without fork" do
+  expected = ".\n"
+
+  out = %x{NO_FORK=true ./bin/cutest -r ./test/keep_pid.rb test/fixtures/check_pid.rb}
+
+  assert_equal(expected, out)
+end
+
+test "running tests works the same" do
+
+  %x{NO_FORK=true ./bin/cutest test/run.rb}
+
+  assert_equal 0, $?.to_i
+
+end


### PR DESCRIPTION
This could enable working in non-forking environments (as required in #9) and
could be usefull to get test-coverage.

I've added some tests.

This is not ready to be merged, as I want to add a check about
`respond_to? :fork` to make it more inteligent.

What do you think about it?
