### PR TITLE
Add return values for assert and assert_equal

### DIFF
--- a/lib/cutest.rb
+++ b/lib/cutest.rb
@@ -152,12 +152,16 @@ private
   def assert(value)
     flunk("expression returned #{value.inspect}") unless value
     success
+
+    value
   end
 
   # Assert that two values are equal.
   def assert_equal(value, other)
     flunk("#{value.inspect} != #{other.inspect}") unless value == other
     success
+
+    true
   end
 
   # Assert that the block doesn't raise the expected exception.

--- a/test/assert.rb
+++ b/test/assert.rb
@@ -2,6 +2,10 @@ test "succeeds if the value is true" do
   assert true
 end
 
+test "returns its value" do
+  assert_equal assert(:value), :value
+end
+
 test "raises if the assertion fails" do
   assert_raise(Cutest::AssertionFailed) do
     assert false

--- a/test/assert_equal.rb
+++ b/test/assert_equal.rb
@@ -2,6 +2,10 @@ test  do
   assert_equal 1, 1
 end
 
+test "returns true" do
+  assert_equal assert_equal(1, 1), true
+end
+
 test "raises if the assertion fails" do
   assert_raise(Cutest::AssertionFailed) do
     assert_equal 1, 2


### PR DESCRIPTION
To be consistent with `assert_raise` (which returns its exception), make `assert` and `assert_equal` return a value more informative than `nil`.
- `assert` will return the value it has been passed.
- `assert_equal` will return `true`. It can't return a more useful value, because `1` might be equal to `2` if `#==` has been redefined.
