### PR TITLE
Custom Assertion Messages

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -38,6 +38,10 @@ equal; and `assert_raise`, that executes a passed block and compares the raised
 exception to the expected one. In all cases, if the expectation is no met, an
 `AssertionFailed` exception is raised.
 
+You can customize the output of `assert` by providing a second argument with
+a string you want to get as an error report if the assertion is not fulfilled.
+This can also be used as a simple building block to build custom assertions.
+
 Usage
 -----
 
@@ -97,6 +101,16 @@ The tests in these two examples will pass.
 
 Unlike other testing frameworks, Cutest does not compile all the tests before
 running them.
+
+A simple example for adding a custom `empty` assertion:
+
+    def assert_empty(string)
+      assert(string.empty?, "not empty")
+    end
+
+    test "failed custom assertion" do
+      assert_empty "foo"
+    end
 
 Handling errors
 ---------------

--- a/lib/cutest.rb
+++ b/lib/cutest.rb
@@ -149,15 +149,14 @@ private
   end
 
   # Assert that value is not nil or false.
-  def assert(value)
-    flunk("expression returned #{value.inspect}") unless value
+  def assert(value, msg = "expression returned #{value.inspect}")
+    flunk(msg) unless value
     success
   end
 
   # Assert that two values are equal.
   def assert_equal(value, other)
-    flunk("#{value.inspect} != #{other.inspect}") unless value == other
-    success
+    assert(value == other, "#{value.inspect} != #{other.inspect}")
   end
 
   # Assert that the block doesn't raise the expected exception.
@@ -167,8 +166,7 @@ private
     rescue expected => exception
       exception
     ensure
-      flunk("got #{exception.inspect} instead") unless exception.kind_of?(expected)
-      success
+      assert(exception.kind_of?(expected), "got #{exception.inspect} instead")
     end
   end
 

--- a/lib/cutest.rb
+++ b/lib/cutest.rb
@@ -173,8 +173,9 @@ private
   # Stop the tests and raise an error where the message is the last line
   # executed before flunking.
   def flunk(message = nil)
+    backtrace = caller.find { |line| line.include? 'top (required)' }
     exception = Cutest::AssertionFailed.new(message)
-    exception.set_backtrace([caller[1]])
+    exception.set_backtrace(backtrace)
 
     raise exception
   end

--- a/test/fixtures/fail_custom_assertion.rb
+++ b/test/fixtures/fail_custom_assertion.rb
@@ -1,6 +1,5 @@
 def assert_empty(string)
-  flunk("not empty") unless string.empty?
-  success
+  assert(string.empty?, "not empty")
 end
 
 test "failed custom assertion" do

--- a/test/fixtures/fail_custom_message.rb
+++ b/test/fixtures/fail_custom_message.rb
@@ -1,0 +1,3 @@
+test "failed with custom message" do
+  assert("hello".empty?, "not empty")
+end

--- a/test/run.rb
+++ b/test/run.rb
@@ -41,11 +41,23 @@ test "exit code of failed run" do
   assert $?.to_i != 0
 end
 
+test "output of an assertion with custom message" do
+  expected = "\n" +
+             "  test: failed with custom message\n" +
+             "  line: assert(\"hello\".empty?, \"not empty\")\n" +
+             "  file: test/fixtures/fail_custom_message.rb +2\n\n" +
+             "Cutest::AssertionFailed: not empty\n\n"
+
+  out = %x{./bin/cutest test/fixtures/fail_custom_message.rb}
+
+  assert_equal(expected, out)
+end
+
 test "output of custom assertion" do
   expected = "\n" +
              "  test: failed custom assertion\n" +
              "  line: assert_empty \"foo\"\n" +
-             "  file: test/fixtures/fail_custom_assertion.rb +7\n\n" +
+             "  file: test/fixtures/fail_custom_assertion.rb +6\n\n" +
              "Cutest::AssertionFailed: not empty\n\n"
 
   out = %x{./bin/cutest test/fixtures/fail_custom_assertion.rb}


### PR DESCRIPTION
This pull request adds the possibility to add custom assertion messages when using assert. This allows to give better feedback when running a test suite. A simple example for that might be the following:

```ruby
test "failed custom assertion" do
  assert(string.empty?, "not empty")
end
```

This gives better feedback, because it gives a **reason for the failure**.

It also makes the step to a custom assertion very easy when we find that we need this kind of assertion multiple times:

```ruby
def assert_empty(string)
  assert(string.empty?, "not empty")
end

test "failed custom assertion" do
  assert_empty "foo"
end
```

# Background

This arose from a discussion with @tonchis. We talked about his [assert-url](https://github.com/tonchis/assert-url) library. He told me that his library is agnostic of test frameworks, and he explained to me how he managed to do that. It has a drawback though: As it doesn't use `flunk` and `success`, it can't do the same kind of reporting that a built-in or cutest-specific `assert_*` can do (e.g. put a dot onto the command line when it succeeds). And it can't use flunk and success, because this is very specific to cutest. So we discussed the following:

```
[13:33:47]  <moonglum>	My gut reaction would say that if you write a lib that's providing assert_* methods there's one thing you can assume: The person that is using your lib uses assert_* methods (so not Rspec's expect for example).
[13:34:02]  <moonglum>	So I guess it would be save to assume that there's a `assert` method available?
[13:34:09]  <tonchis>	it's a reasonable assumption, yes
[13:35:04]  <moonglum>	So if your lib can break everything down to an `assert` it would be fine, right? In the sense of `assert` can be used as the building block for all assertions
[13:35:40]  <tonchis>	also true
[13:35:42]  <moonglum>	But the problem I see here is that cutest doesn't offer an 'explanation string' in its assert as many frameworks do
[13:36:00]  <tonchis>	yeap
[13:36:04]  <moonglum>	assert false, "EXPLAIN EXPLAIN"
[13:36:33]  <tonchis>	that's useful, may be you can propose it to jano and see what he thinks of it
[13:36:58]  <tonchis>	it wouldn't be hard to implement either, I think
```

# Example for custom assertions with the "new assert"

@tonchis' [assert_schema_equal](https://github.com/tonchis/assert-url/blob/master/lib/assert_url.rb#L16-20):

```ruby
def assert_scheme_equal(expected, value)
  value = urify(value).scheme

  assert(expected.to_s == value, "Expected #{value} to have the following scheme: #{expected}"
end
```

In my opinion: Better error reporting with the same amount of understandable code.

# Impact

* Add optional message argument to assert
* Reimplemented assert_equal and assert_raise with assert
* Totally backwards compatible as the new argument is optional
* Adds little to no complexity, and even removes two lines of code
* Introduces a way to add custom assertions in a straight forward way (without using flunk and success)