### PR TITLE
Make assert_raise work with exceptions not inheriting from StandardError

### DIFF
--- a/lib/cutest.rb
+++ b/lib/cutest.rb
@@ -164,7 +164,7 @@ private
   def assert_raise(expected = Exception)
     begin
       yield
-    rescue => exception
+    rescue expected => exception
       exception
     ensure
       flunk("got #{exception.inspect} instead") unless exception.kind_of?(expected)

--- a/test/assert_raise.rb
+++ b/test/assert_raise.rb
@@ -4,7 +4,7 @@ test "catches the right exception" do
   end
 end
 
-test "can catch exceptions not inheriting from StandardError" do
+test "catches exceptions lower than StandardError" do
   assert_raise(NotImplementedError) do
     raise NotImplementedError
   end

--- a/test/assert_raise.rb
+++ b/test/assert_raise.rb
@@ -4,6 +4,12 @@ test "catches the right exception" do
   end
 end
 
+test "can catch exceptions not inheriting from StandardError" do
+  assert_raise(NotImplementedError) do
+    raise NotImplementedError
+  end
+end
+
 test "raises if the expectation is not met" do
   assert_raise(Cutest::AssertionFailed) do
     assert_raise(RuntimeError) do
@@ -19,4 +25,3 @@ test "returns the exception" do
 
   assert_equal "error", exception.message
 end
-


### PR DESCRIPTION
The rescue block in `assert_raise` does not qualify which exceptions to rescue. That means `assert_raise` can only make assertions on methods that raise exceptions inheriting from `StandardError`. 

Currently `assert_raise` flunks the test when making an assertion on, for example, a `NotImplementedError`.

**test.rb**
```ruby
test do
  assert_raise(NotImplementedError) do
    raise NotImplementedError
  end
end
```

**output**
```
$ cutest test.rb

  test: 

Cutest::AssertionFailed: got nil instead
```