### PR TITLE
Add #assert_nothing_raised assertion

### DIFF
--- a/lib/cutest.rb
+++ b/lib/cutest.rb
@@ -160,7 +160,7 @@ private
     success
   end
 
-  # Assert that the block doesn't raise the expected exception.
+  # Assert that the block raises only the expected exception.
   def assert_raise(expected = Exception)
     begin
       yield
@@ -170,6 +170,14 @@ private
       flunk("got #{exception.inspect} instead") unless exception.kind_of?(expected)
       success
     end
+  end
+  
+  # Assert that the block raises no exceptions.
+  def assert_nothing_raised
+    yield
+    success
+  rescue Exception => exception
+    flunk("got #{exception.inspect} instead of nothing")
   end
 
   # Stop the tests and raise an error where the message is the last line


### PR DESCRIPTION
A counterpart to `#assert_raised` that asserts that the block raises no exception.

- Also fix the documentation of `#assert_raised`.