### PR TITLE
Fix error message of assert_raise

### DIFF
--- a/lib/cutest.rb
+++ b/lib/cutest.rb
@@ -161,13 +161,13 @@ private
 
   # Assert that the block raises an expected exception.
   def assert_raise(expected = Exception)
-    begin
-      yield
-    rescue expected => exception
-      exception
-    ensure
-      assert(exception.kind_of?(expected), "got #{exception.inspect} instead")
-    end
+    result = yield
+  rescue expected => actual
+    actual
+  rescue => actual
+    actual
+  ensure
+    assert(actual.kind_of?(expected), "got #{(actual || result).inspect} instead")
   end
 
   # Stop the tests and raise an error where the message is the last line

--- a/test/assert.rb
+++ b/test/assert.rb
@@ -7,3 +7,11 @@ test "raises if the assertion fails" do
     assert false
   end
 end
+
+test "provides a helpful message" do
+  exception = assert_raise(Cutest::AssertionFailed) do
+    assert false
+  end
+
+  assert_equal "expression returned false", exception.message
+end

--- a/test/assert_equal.rb
+++ b/test/assert_equal.rb
@@ -7,3 +7,11 @@ test "raises if the assertion fails" do
     assert_equal 1, 2
   end
 end
+
+test "provides a helpful error message" do
+  exception = assert_raise(Cutest::AssertionFailed) do
+    assert_equal 1, 2
+  end
+
+  assert_equal "1 != 2", exception.message
+end

--- a/test/assert_raise.rb
+++ b/test/assert_raise.rb
@@ -38,6 +38,30 @@ test "returns the exception" do
   assert_equal "error", exception.message
 end
 
+test "provides a helpful error message" do
+  exception = assert_raise(Cutest::AssertionFailed) do
+    assert_raise(RuntimeError) do
+      raise ArgumentError
+    end
+  end
+
+  assert_equal "got #<ArgumentError: ArgumentError> instead", exception.message
+
+  exception = assert_raise(Cutest::AssertionFailed) do
+    assert_raise { "foo" }
+  end
+
+  assert_equal "got \"foo\" instead", exception.message
+end
+
+test "considers an exception as return value a failure" do
+  assert_raise(Cutest::AssertionFailed) do
+    assert_raise(RuntimeError) do
+      RuntimeError.new
+    end
+  end
+end
+
 test "catches a custom exception" do
   assert_raise do
     raise Class.new(Exception)


### PR DESCRIPTION
Since commit f6b140c `assert_raise` started using the second argument of `assert` for error messages. The error message was always `"got nil instead"`. The reason is that the local variable `exception` only has a value in case of success. In case of failure its value is `nil`.

This pull request adds a test for the error message of each assertion method (`assert`, `assert_equal` and `assert_raise`) and fixes `assert_raise` to construct the expected error message in case of failure.